### PR TITLE
Fixed typo for the descriptive text for the Sorceress minor title.

### DIFF
--- a/MOD/Witcher/localisation/W_minor_titles.csv
+++ b/MOD/Witcher/localisation/W_minor_titles.csv
@@ -2,7 +2,7 @@
 title_sorcerer;Sorcerer;;;;;;;;;;;;;x
 title_sorcerer_desc;Minor title given automatically to male characters with the sorcerer trait.;;;;;;;;;;;;;x
 title_sorceress;Sorceress;;;;;;;;;;;;;x
-title_sorceres_desc;Minor title given automatically to female characters with the sorcerer trait.;;;;;;;;;;;;;x
+title_sorceress_desc;Minor title given automatically to female characters with the sorcerer trait.;;;;;;;;;;;;;x
 title_druid;Druid;;;;;;;;;;;;;x
 title_druid_desc;Minor title given automatically to characters with the druid trait.;;;;;;;;;;;;;x
 title_blue_stripes_commander;Commander of the Blue Stripes;;;;;;;;;;;;;x


### PR DESCRIPTION
Verified in a saved game that I loaded.